### PR TITLE
Map Style: show structures_exits

### DIFF
--- a/web/src/map_style.json
+++ b/web/src/map_style.json
@@ -1456,6 +1456,17 @@
       }
     },
     {
+      "id": "structures_exits",
+      "type": "line",
+      "source": "site_plan",
+      "source-layer": "structures_exits_linestring",
+      "minzoom": 0,
+      "paint": {
+        "line-width": 3,
+        "line-color": "rgb(153, 144, 93)"
+      }
+    },
+    {
       "id": "structures_internal_linestring",
       "type": "line",
       "source": "site_plan",


### PR DESCRIPTION
This might be useful during build up
Entrance, Info, First Aid, Shop and Youth tents (Lounge, Workshop, etc) are missing them in the GIS


![Screenshot 2022-05-10 at 08 13 16](https://user-images.githubusercontent.com/234460/167570857-1f40a11e-3637-4f01-a01b-62d807fc0bde.png)
