### PR TITLE
Quality of life and bug fixes

### DIFF
--- a/web/src/style/map_style.ts
+++ b/web/src/style/map_style.ts
@@ -25,7 +25,9 @@ const style: StyleSpecification = {
     },
     villages: {
       type: 'geojson',
-      data: 'https://www.emfcamp.org/api/villages.geojson',
+      data: import.meta.env.DEV
+        ? 'http://localhost:2342/api/villages.geojson'
+        : 'https://www.emfcamp.org/api/villages.geojson',
     },
     slope: {
       type: 'raster',

--- a/web/src/villages/components.ts
+++ b/web/src/villages/components.ts
@@ -1,6 +1,15 @@
 import { el, setChildren, mount, RedomComponent } from 'redom'
 import { Village } from './index.ts'
 
+function villageLngLat(v: Village): [number | null, number | null] {
+  const location = v?.location as GeoJSON.Point | null | undefined
+  if (location?.type === 'Point') {
+    const [lng, lat] = location.coordinates
+    return [lng, lat]
+  }
+  return [null, null]
+}
+
 class VillageSelector implements RedomComponent {
   el: HTMLElement
   onSelected: any
@@ -8,7 +17,10 @@ class VillageSelector implements RedomComponent {
   villages: Village[]
 
   constructor(villages: Village[], selected?: number) {
-    this.villages = villages
+    this.villages = [...villages].sort((a, b) =>
+      (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' })
+    )
+    villages = this.villages
 
     if (!selected) {
       selected = villages[0].id
@@ -81,14 +93,16 @@ export class PlaceVillageDialog implements RedomComponent {
     this.village_selector = new VillageSelector(villages)
     const selected_village = this.village_selector.getSelected()!
 
-    this.location_selector = new LocationSelector(this.map, selected_village.lng, selected_village.lat)
+    const [vlng, vlat] = villageLngLat(selected_village)
+    this.location_selector = new LocationSelector(this.map, vlng as any, vlat as any)
 
     this.location_selector.onSelect = () => {
       submit_button.removeAttribute('disabled')
     }
 
     this.village_selector.onSelected = (village: Village) => {
-      this.location_selector!.setLocation(village.lng, village.lat)
+      const [lng, lat] = villageLngLat(village)
+      this.location_selector!.setLocation(lng, lat)
     }
 
     const form = el(
@@ -117,7 +131,11 @@ export class PlaceVillageDialog implements RedomComponent {
 
     if (!village) return null
 
-    village.location = [this.location_selector!.lng, this.location_selector!.lat]
+    const lng = this.location_selector!.lng
+    const lat = this.location_selector!.lat
+    if (lng != null && lat != null) {
+      village.location = [lng, lat]
+    }
 
     return village
   }


### PR DESCRIPTION
- Read village location from GeoJSON location.coordinates instead of nonexistent lng/lat fields, so the editor prefills existing positions
- Only send location on save when one is set, avoiding null Point errors
- Sort the village admin dropdown alphabetically by name
- Use the local backend for villages in dev mode