### PR TITLE
Venue navigation based on URL fragment

### DIFF
--- a/web/src/components/map.ts
+++ b/web/src/components/map.ts
@@ -5,7 +5,8 @@ import { customElement, property } from 'lit/decorators.js'
 import maplibregl from 'maplibre-gl'
 import map_style from '../style/map_style.ts'
 import Marker from '../marker.ts'
-import { Layer, LayerGroup, LayerSwitcher, URLHash } from '@russss/maplibregl-layer-switcher'
+import { Layer, LayerGroup, LayerSwitcher } from '@russss/maplibregl-layer-switcher'
+import VenueURLHash from '../venueurlhash.ts'
 import ContextMenu from './contextmenu.ts'
 import { roundPosition } from '../util.ts'
 import { setupPhones } from '../phones.ts'
@@ -127,7 +128,7 @@ export class EMFMap extends LitElement {
   ]
   map?: maplibregl.Map
   layer_switcher?: LayerSwitcher
-  url_hash?: URLHash
+  url_hash?: VenueURLHash
   markerComponent?: Marker
 
   /* Whether extended nav controls are present (zoom in/out buttons, and geolocate control) */
@@ -182,7 +183,7 @@ export class EMFMap extends LitElement {
     this.layer_switcher = new LayerSwitcher(this.layer_config)
 
     if (this.urlHash) {
-      this.url_hash = new URLHash(this.layer_switcher)
+      this.url_hash = new VenueURLHash(this.layer_switcher)
       this.layer_switcher.urlhash = this.url_hash
       map_options = this.url_hash.init(map_options)
     }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -34,7 +34,7 @@ export class EMFMapApp extends LitElement {
     const map = mapComponent.map!
 
     map.addControl(new DistanceMeasure(), 'top-right')
-    map.addControl(new SearchControl(), 'top-right')
+    map.addControl(new SearchControl(mapComponent.url_hash), 'top-right')
     map.addControl(new InstallControl(), 'top-left')
 
     map.addControl(new VillagesEditor('villages', 'villages_symbol'), 'top-right')

--- a/web/src/search/searchcontrol.ts
+++ b/web/src/search/searchcontrol.ts
@@ -1,6 +1,8 @@
 import { el, mount } from 'redom'
 import maplibregl, { GeoJSONSource, LngLatBounds } from 'maplibre-gl'
 import type { SearchCategory, SearchEntry, SearchIndex } from './searchindex.ts'
+import { slugify } from '../venueurlhash.ts'
+import type VenueURLHash from '../venueurlhash.ts'
 
 const categoryZoom: Record<SearchCategory, number> = {
   structure: 18,
@@ -38,10 +40,14 @@ class SearchControl implements maplibregl.IControl {
   _index?: SearchIndex
   _indexError: boolean = false
   _searchFn?: typeof import('./searchindex.ts').search
+  _resolveFn?: typeof import('./searchindex.ts').resolveSlug
   _results: SearchEntry[] = []
   _activeIndex: number = -1
+  _urlHash?: VenueURLHash
+  _pendingSlug: string | null = null
 
-  constructor() {
+  constructor(urlHash?: VenueURLHash) {
+    this._urlHash = urlHash
     this._toggleButton = el('button.search-toggle', {
       type: 'button',
       'aria-label': 'Search venues',
@@ -112,12 +118,29 @@ class SearchControl implements maplibregl.IControl {
     // The container isn't attached to the corner element until onAdd returns.
     queueMicrotask(() => this._container.parentElement?.prepend(this._container))
 
+    if (this._urlHash) {
+      this._urlHash.onVenueSlug = (slug) => {
+        if (slug) {
+          this._resolveSlug(slug)
+        } else {
+          this._pendingSlug = null
+        }
+      }
+      // The page may have loaded with a venue hash (e.g. #stage-a), stashed
+      // by VenueURLHash before this control existed
+      if (this._urlHash.venueSlug) {
+        this._resolveSlug(this._urlHash.venueSlug)
+      }
+    }
+
     return this._container
   }
 
   onRemove() {
     this._setHighlights([])
     this._collapse()
+    if (this._urlHash) this._urlHash.onVenueSlug = undefined
+    this._pendingSlug = null
     this._container.parentNode?.removeChild(this._container)
     this._map = undefined
   }
@@ -154,10 +177,12 @@ class SearchControl implements maplibregl.IControl {
     this._indexPromise ??= import('./searchindex.ts')
       .then(async (module) => {
         this._searchFn = module.search
+        this._resolveFn = module.resolveSlug
         this._indexError = false
         this._index = await module.buildIndex(map, () => {
           // Villages can merge in after the first render
           if (this._container.classList.contains('expanded')) this._renderResults()
+          if (this._pendingSlug) this._attemptSlugResolution()
         })
         this._renderResults()
       })
@@ -171,10 +196,48 @@ class SearchControl implements maplibregl.IControl {
       })
   }
 
+  /* Resolve a venue slug from the URL hash (page load, URL edit, history
+     navigation) against the search index */
+  async _resolveSlug(slug: string) {
+    this._pendingSlug = slug
+    this._ensureIndex()
+    await this._indexPromise
+    if (this._indexError) {
+      // Without an index the slug can never resolve; drop it so a later
+      // successful index build doesn't teleport the map unexpectedly
+      console.warn(`Search: cannot resolve #${slug} — index unavailable`)
+      this._pendingSlug = null
+      return
+    }
+    this._attemptSlugResolution()
+  }
+
+  _attemptSlugResolution() {
+    const slug = this._pendingSlug
+    if (!slug || !this._index || !this._resolveFn) return
+    // A user gesture during the async gap may have cleared the slug
+    if (this._urlHash?.venueSlug !== slug) {
+      this._pendingSlug = null
+      return
+    }
+    const entries = this._resolveFn(this._index.entries, slug)
+    if (entries.length === 0) {
+      // Kept pending: villages may still merge in and resolve it
+      console.warn(`Search: no venue matches #${slug}`)
+      return
+    }
+    this._pendingSlug = null
+    if (entries.length === 1) {
+      this._input.value = entries[0].displayName
+    }
+    this._focusEntries(entries)
+  }
+
   /* Clear query, results and highlights */
   _clear() {
     this._input.value = ''
     this._setHighlights([])
+    this._urlHash?.setVenueSlug(null)
     this._renderResults()
   }
 
@@ -186,6 +249,7 @@ class SearchControl implements maplibregl.IControl {
       this._input.focus()
     } else {
       this._setHighlights([])
+      this._urlHash?.setVenueSlug(null)
       this._collapse()
       this._toggleButton.focus()
     }
@@ -301,23 +365,44 @@ class SearchControl implements maplibregl.IControl {
     this._input.removeAttribute('aria-activedescendant')
   }
 
+  /* Highlight entries and move the camera: one entry flies in close, several
+     are framed together. Shared by search selection and URL slug resolution. */
+  _focusEntries(entries: SearchEntry[]) {
+    this._setHighlights(entries)
+    if (entries.length === 1) {
+      const entry = entries[0]
+      this._map?.flyTo({ center: entry.coords, zoom: categoryZoom[entry.category] })
+    } else {
+      const bounds = entries.reduce(
+        (b, entry) => b.extend(entry.coords),
+        new LngLatBounds(entries[0].coords, entries[0].coords)
+      )
+      this._map?.fitBounds(bounds, {
+        padding: { top: 90, bottom: 50, left: 50, right: 50 },
+        maxZoom: MULTI_RESULT_MAX_ZOOM,
+      })
+    }
+  }
+
   _select(entry: SearchEntry) {
-    this._setHighlights([entry])
-    this._map?.flyTo({ center: entry.coords, zoom: categoryZoom[entry.category] })
+    // Set before the camera move so the flight's moveend writes the slug hash
+    this._urlHash?.setVenueSlug(entry.slug)
+    this._focusEntries([entry])
     this._afterSelection()
   }
 
   _selectAll() {
-    const results = this._results
-    this._setHighlights(results)
-    const bounds = results.reduce(
-      (b, entry) => b.extend(entry.coords),
-      new LngLatBounds(results[0].coords, results[0].coords)
-    )
-    this._map?.fitBounds(bounds, {
-      padding: { top: 90, bottom: 50, left: 50, right: 50 },
-      maxZoom: MULTI_RESULT_MAX_ZOOM,
-    })
+    if (this._urlHash) {
+      // Only mint a slug the resolver would round-trip (e.g. #parking), never
+      // a dead link from a partial query like "sta"
+      const slug = slugify(this._input.value.trim())
+      const resolvable =
+        /^[a-z]/.test(slug) && this._index && this._resolveFn
+          ? this._resolveFn(this._index.entries, slug)
+          : []
+      this._urlHash.setVenueSlug(resolvable.length > 0 ? slug : null)
+    }
+    this._focusEntries(this._results)
     this._afterSelection()
   }
 

--- a/web/src/search/searchcontrol.ts
+++ b/web/src/search/searchcontrol.ts
@@ -1,7 +1,7 @@
 import { el, mount } from 'redom'
 import maplibregl, { GeoJSONSource, LngLatBounds } from 'maplibre-gl'
 import type { SearchCategory, SearchEntry, SearchIndex } from './searchindex.ts'
-import { slugify } from '../venueurlhash.ts'
+import { slugify, isVenueSlug, VENUE_MOVE } from '../venueurlhash.ts'
 import type VenueURLHash from '../venueurlhash.ts'
 
 const categoryZoom: Record<SearchCategory, number> = {
@@ -90,7 +90,14 @@ class SearchControl implements maplibregl.IControl {
       this._clear()
       this._input.focus()
     })
-    this._input.addEventListener('input', () => this._renderResults())
+    this._input.addEventListener('input', () => {
+      // Typing takes over from any in-flight URL slug resolution
+      if (this._pendingSlug) {
+        this._pendingSlug = null
+        this._urlHash?.setVenueSlug(null)
+      }
+      this._renderResults()
+    })
     this._input.addEventListener('focus', () => this._renderResults())
     this._input.addEventListener('keydown', (e) => this._onInputKeyDown(e))
     // Escape works from anywhere in the expanded bar, not just the input
@@ -180,9 +187,10 @@ class SearchControl implements maplibregl.IControl {
         this._resolveFn = module.resolveSlug
         this._indexError = false
         this._index = await module.buildIndex(map, () => {
-          // Villages can merge in after the first render
+          // Villages can merge in after the first render; this callback also
+          // marks the index as final
           if (this._container.classList.contains('expanded')) this._renderResults()
-          if (this._pendingSlug) this._attemptSlugResolution()
+          if (this._pendingSlug) this._attemptSlugResolution(true)
         })
         this._renderResults()
       })
@@ -212,7 +220,7 @@ class SearchControl implements maplibregl.IControl {
     this._attemptSlugResolution()
   }
 
-  _attemptSlugResolution() {
+  _attemptSlugResolution(indexFinal: boolean = false) {
     const slug = this._pendingSlug
     if (!slug || !this._index || !this._resolveFn) return
     // A user gesture during the async gap may have cleared the slug
@@ -222,8 +230,14 @@ class SearchControl implements maplibregl.IControl {
     }
     const entries = this._resolveFn(this._index.entries, slug)
     if (entries.length === 0) {
-      // Kept pending: villages may still merge in and resolve it
       console.warn(`Search: no venue matches #${slug}`)
+      if (indexFinal) {
+        // Dead link (typo or renamed venue): give up and revert the URL so a
+        // late village merge can't teleport the user afterwards
+        this._pendingSlug = null
+        this._urlHash?.setVenueSlug(null)
+      }
+      // Otherwise kept pending: villages may still merge in and resolve it
       return
     }
     this._pendingSlug = null
@@ -369,18 +383,24 @@ class SearchControl implements maplibregl.IControl {
      are framed together. Shared by search selection and URL slug resolution. */
   _focusEntries(entries: SearchEntry[]) {
     this._setHighlights(entries)
+    // VENUE_MOVE marks these camera moves as venue-initiated so VenueURLHash
+    // doesn't treat them as the user navigating away
     if (entries.length === 1) {
       const entry = entries[0]
-      this._map?.flyTo({ center: entry.coords, zoom: categoryZoom[entry.category] })
+      this._map?.flyTo({ center: entry.coords, zoom: categoryZoom[entry.category] }, VENUE_MOVE)
     } else {
       const bounds = entries.reduce(
         (b, entry) => b.extend(entry.coords),
         new LngLatBounds(entries[0].coords, entries[0].coords)
       )
-      this._map?.fitBounds(bounds, {
-        padding: { top: 90, bottom: 50, left: 50, right: 50 },
-        maxZoom: MULTI_RESULT_MAX_ZOOM,
-      })
+      this._map?.fitBounds(
+        bounds,
+        {
+          padding: { top: 90, bottom: 50, left: 50, right: 50 },
+          maxZoom: MULTI_RESULT_MAX_ZOOM,
+        },
+        VENUE_MOVE
+      )
     }
   }
 
@@ -393,14 +413,19 @@ class SearchControl implements maplibregl.IControl {
 
   _selectAll() {
     if (this._urlHash) {
-      // Only mint a slug the resolver would round-trip (e.g. #parking), never
-      // a dead link from a partial query like "sta"
+      // Only mint a slug when a link recipient would see exactly what the
+      // sharer sees: the slug must resolve to the same set search() framed
+      // (search is fuzzy, resolveSlug is not — e.g. "stage" fuzzy-matches
+      // "Backstage" but #stage would not)
       const slug = slugify(this._input.value.trim())
-      const resolvable =
-        /^[a-z]/.test(slug) && this._index && this._resolveFn
-          ? this._resolveFn(this._index.entries, slug)
-          : []
-      this._urlHash.setVenueSlug(resolvable.length > 0 ? slug : null)
+      let roundTrips = false
+      if (isVenueSlug(slug) && this._index && this._resolveFn) {
+        const resolved = this._resolveFn(this._index.entries, slug)
+        const resolvedKeys = resolved.map((e) => e.slug + '@' + e.coords.join()).sort()
+        const resultKeys = this._results.map((e) => e.slug + '@' + e.coords.join()).sort()
+        roundTrips = resolved.length > 0 && resolvedKeys.join('|') === resultKeys.join('|')
+      }
+      this._urlHash.setVenueSlug(roundTrips ? slug : null)
     }
     this._focusEntries(this._results)
     this._afterSelection()

--- a/web/src/search/searchcontrol.ts
+++ b/web/src/search/searchcontrol.ts
@@ -133,8 +133,7 @@ class SearchControl implements maplibregl.IControl {
           this._pendingSlug = null
         }
       }
-      // The page may have loaded with a venue hash (e.g. #stage-a), stashed
-      // by VenueURLHash before this control existed
+      // Consume a venue hash the page loaded with, stashed before onAdd ran
       if (this._urlHash.venueSlug) {
         this._resolveSlug(this._urlHash.venueSlug)
       }
@@ -187,8 +186,7 @@ class SearchControl implements maplibregl.IControl {
         this._resolveFn = module.resolveSlug
         this._indexError = false
         this._index = await module.buildIndex(map, () => {
-          // Villages can merge in after the first render; this callback also
-          // marks the index as final
+          // Fires when villages merge in, which also makes the index final
           if (this._container.classList.contains('expanded')) this._renderResults()
           if (this._pendingSlug) this._attemptSlugResolution(true)
         })
@@ -204,15 +202,12 @@ class SearchControl implements maplibregl.IControl {
       })
   }
 
-  /* Resolve a venue slug from the URL hash (page load, URL edit, history
-     navigation) against the search index */
+  /* Resolve a venue slug from the URL hash against the search index */
   async _resolveSlug(slug: string) {
     this._pendingSlug = slug
     this._ensureIndex()
     await this._indexPromise
     if (this._indexError) {
-      // Without an index the slug can never resolve; drop it so a later
-      // successful index build doesn't teleport the map unexpectedly
       console.warn(`Search: cannot resolve #${slug} — index unavailable`)
       this._pendingSlug = null
       return
@@ -230,14 +225,12 @@ class SearchControl implements maplibregl.IControl {
     }
     const entries = this._resolveFn(this._index.entries, slug)
     if (entries.length === 0) {
+      // Kept pending until the index is final: villages may still resolve it
       console.warn(`Search: no venue matches #${slug}`)
       if (indexFinal) {
-        // Dead link (typo or renamed venue): give up and revert the URL so a
-        // late village merge can't teleport the user afterwards
         this._pendingSlug = null
         this._urlHash?.setVenueSlug(null)
       }
-      // Otherwise kept pending: villages may still merge in and resolve it
       return
     }
     this._pendingSlug = null
@@ -383,8 +376,7 @@ class SearchControl implements maplibregl.IControl {
      are framed together. Shared by search selection and URL slug resolution. */
   _focusEntries(entries: SearchEntry[]) {
     this._setHighlights(entries)
-    // VENUE_MOVE marks these camera moves as venue-initiated so VenueURLHash
-    // doesn't treat them as the user navigating away
+    // VENUE_MOVE stops VenueURLHash treating these moves as navigating away
     if (entries.length === 1) {
       const entry = entries[0]
       this._map?.flyTo({ center: entry.coords, zoom: categoryZoom[entry.category] }, VENUE_MOVE)
@@ -405,7 +397,6 @@ class SearchControl implements maplibregl.IControl {
   }
 
   _select(entry: SearchEntry) {
-    // Set before the camera move so the flight's moveend writes the slug hash
     this._urlHash?.setVenueSlug(entry.slug)
     this._focusEntries([entry])
     this._afterSelection()
@@ -413,19 +404,14 @@ class SearchControl implements maplibregl.IControl {
 
   _selectAll() {
     if (this._urlHash) {
-      // Only mint a slug when a link recipient would see exactly what the
-      // sharer sees: the slug must resolve to the same set search() framed
-      // (search is fuzzy, resolveSlug is not — e.g. "stage" fuzzy-matches
-      // "Backstage" but #stage would not)
+      // Only mint a slug that resolves to exactly what search() framed, so a
+      // link recipient sees what the sharer saw (search is fuzzier than slugs)
       const slug = slugify(this._input.value.trim())
-      let roundTrips = false
-      if (isVenueSlug(slug) && this._index && this._resolveFn) {
-        const resolved = this._resolveFn(this._index.entries, slug)
-        const resolvedKeys = resolved.map((e) => e.slug + '@' + e.coords.join()).sort()
-        const resultKeys = this._results.map((e) => e.slug + '@' + e.coords.join()).sort()
-        roundTrips = resolved.length > 0 && resolvedKeys.join('|') === resultKeys.join('|')
-      }
-      this._urlHash.setVenueSlug(roundTrips ? slug : null)
+      const resolved =
+        isVenueSlug(slug) && this._index && this._resolveFn ? this._resolveFn(this._index.entries, slug) : []
+      const roundTrips =
+        resolved.length === this._results.length && resolved.every((entry) => this._results.includes(entry))
+      this._urlHash.setVenueSlug(roundTrips && resolved.length > 0 ? slug : null)
     }
     this._focusEntries(this._results)
     this._afterSelection()

--- a/web/src/search/searchindex.ts
+++ b/web/src/search/searchindex.ts
@@ -71,12 +71,10 @@ function makeEntry(
   }
 }
 
-/* Resolve a URL venue slug to entries, most-specific tier first:
-   1. exact — duplicate names resolve together
-   2. prefix at a hyphen boundary — #parking matches every "Parking: …"
-   3. containment at hyphen boundaries — #robot-arms matches "The Robot Arms"
-   Hyphen boundaries keep it predictable: #stage never matches "Backstage".
-   Deliberately not fuzzy: URL slugs should be guessable and stable. */
+/* Resolve a URL venue slug, most-specific tier first: exact, then prefix,
+   then containment — always at hyphen boundaries, so #parking matches every
+   "Parking: …", #robot-arms matches "The Robot Arms", and #stage can never
+   match "Backstage". Deliberately not fuzzy: slugs should be guessable. */
 export function resolveSlug(entries: SearchEntry[], slug: string): SearchEntry[] {
   const exact = entries.filter((entry) => entry.slug === slug)
   if (exact.length > 0) return exact
@@ -229,15 +227,14 @@ async function villageEntries(map: maplibregl.Map): Promise<SearchEntry[]> {
 }
 
 export async function buildIndex(map: maplibregl.Map, onUpdate?: () => void): Promise<SearchIndex> {
-  // Start both loads concurrently, but never block on villages: getData()
-  // does not settle while the villages source is unreachable, so they merge
-  // in whenever they arrive and onUpdate lets the UI refresh
+  // Never block on villages: getData() doesn't settle while their source is
+  // unreachable. They merge in whenever they arrive; onUpdate fires even when
+  // empty, doubling as the "index is final" signal.
   const villagesPromise = villageEntries(map)
   const sitePlan = await sitePlanEntries(map)
   const index: SearchIndex = { entries: sitePlan.entries, offline: sitePlan.offline }
   villagesPromise.then((villages) => {
     for (const village of villages) index.entries.push(village)
-    // Fires even with no villages: it doubles as the "index is final" signal
     onUpdate?.()
   })
   return index

--- a/web/src/search/searchindex.ts
+++ b/web/src/search/searchindex.ts
@@ -2,12 +2,14 @@ import { VectorTile } from '@mapbox/vector-tile'
 import Pbf from 'pbf'
 import maplibregl, { GeoJSONSource } from 'maplibre-gl'
 import { center } from '../style/map_style.ts'
+import { slugify } from '../venueurlhash.ts'
 
 export type SearchCategory = 'structure' | 'area' | 'camping' | 'parking' | 'gate' | 'village'
 
 export interface SearchEntry {
   displayName: string
   normalized: string
+  slug: string
   category: SearchCategory
   coords: [number, number]
   importance: number
@@ -66,10 +68,21 @@ function makeEntry(
   return {
     displayName,
     normalized: normalize(displayName),
+    slug: slugify(displayName),
     category,
     coords: geometry.coordinates as [number, number],
     importance,
   }
+}
+
+/* Resolve a URL venue slug to entries. Exact matches win (duplicate names
+   resolve together); otherwise fall back to hyphen-boundary prefixes so
+   #parking matches every "Parking: …" entry but #stage never matches
+   "Backstage". Deliberately not fuzzy: URL slugs should be predictable. */
+export function resolveSlug(entries: SearchEntry[], slug: string): SearchEntry[] {
+  const exact = entries.filter((entry) => entry.slug === slug)
+  if (exact.length > 0) return exact
+  return entries.filter((entry) => entry.slug.startsWith(slug + '-'))
 }
 
 interface LayerExtractor {

--- a/web/src/search/searchindex.ts
+++ b/web/src/search/searchindex.ts
@@ -71,14 +71,18 @@ function makeEntry(
   }
 }
 
-/* Resolve a URL venue slug to entries. Exact matches win (duplicate names
-   resolve together); otherwise fall back to hyphen-boundary prefixes so
-   #parking matches every "Parking: …" entry but #stage never matches
-   "Backstage". Deliberately not fuzzy: URL slugs should be predictable. */
+/* Resolve a URL venue slug to entries, most-specific tier first:
+   1. exact — duplicate names resolve together
+   2. prefix at a hyphen boundary — #parking matches every "Parking: …"
+   3. containment at hyphen boundaries — #robot-arms matches "The Robot Arms"
+   Hyphen boundaries keep it predictable: #stage never matches "Backstage".
+   Deliberately not fuzzy: URL slugs should be guessable and stable. */
 export function resolveSlug(entries: SearchEntry[], slug: string): SearchEntry[] {
   const exact = entries.filter((entry) => entry.slug === slug)
   if (exact.length > 0) return exact
-  return entries.filter((entry) => entry.slug.startsWith(slug + '-'))
+  const prefixed = entries.filter((entry) => entry.slug.startsWith(slug + '-'))
+  if (prefixed.length > 0) return prefixed
+  return entries.filter((entry) => entry.slug.includes('-' + slug + '-') || entry.slug.endsWith('-' + slug))
 }
 
 interface LayerExtractor {

--- a/web/src/search/searchindex.ts
+++ b/web/src/search/searchindex.ts
@@ -2,7 +2,7 @@ import { VectorTile } from '@mapbox/vector-tile'
 import Pbf from 'pbf'
 import maplibregl, { GeoJSONSource } from 'maplibre-gl'
 import { center } from '../style/map_style.ts'
-import { slugify } from '../venueurlhash.ts'
+import { fold, slugify } from '../venueurlhash.ts'
 
 export type SearchCategory = 'structure' | 'area' | 'camping' | 'parking' | 'gate' | 'village'
 
@@ -31,11 +31,7 @@ const TILE_FETCH_TIMEOUT_MS = 5000
 const DEFAULT_IMPORTANCE = 3
 
 function normalize(s: string): string {
-  return s
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
+  return fold(s).trim()
 }
 
 function tileForPoint(lng: number, lat: number, z: number): { x: number; y: number } {
@@ -236,8 +232,8 @@ export async function buildIndex(map: maplibregl.Map, onUpdate?: () => void): Pr
   const sitePlan = await sitePlanEntries(map)
   const index: SearchIndex = { entries: sitePlan.entries, offline: sitePlan.offline }
   villagesPromise.then((villages) => {
-    if (villages.length === 0) return
     for (const village of villages) index.entries.push(village)
+    // Fires even with no villages: it doubles as the "index is final" signal
     onUpdate?.()
   })
   return index

--- a/web/src/venueurlhash.ts
+++ b/web/src/venueurlhash.ts
@@ -1,8 +1,7 @@
 import { URLHash } from '@russss/maplibregl-layer-switcher'
 import type maplibregl from 'maplibre-gl'
 
-/* Strip diacritics and lowercase. Shared by slugify and the search index's
-   normalize so URL matching and search matching can never drift apart. */
+/* Strip diacritics and lowercase; shared with the search index's normalize */
 export function fold(s: string): string {
   return s
     .normalize('NFD')
@@ -10,36 +9,19 @@ export function fold(s: string): string {
     .toLowerCase()
 }
 
-// Letters that NFD leaves undecomposed, mapped so venue names like "Røde Bar"
-// still get a predictable slug (rode-bar, not r-de-bar)
-const TRANSLITERATIONS: Record<string, string> = {
-  ø: 'o',
-  æ: 'ae',
-  ß: 'ss',
-  ł: 'l',
-  đ: 'd',
-  ð: 'd',
-  þ: 'th',
-}
-
-/* Canonical URL slug for a venue name: "Stage A" -> "stage-a",
-   "Parking: Main" -> "parking-main", "Crêche" -> "creche" */
+/* "Stage A" -> "stage-a", "Parking: Main" -> "parking-main", "Crêche" -> "creche" */
 export function slugify(name: string): string {
   return fold(name)
-    .replace(/[øæßłđðþ]/g, (c) => TRANSLITERATIONS[c])
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
 }
 
-/* Venue slugs must start with a letter so numeric fragments are never
-   mistaken for venues */
+/* Slugs start with a letter, so numeric fragments are never venues */
 export function isVenueSlug(slug: string): boolean {
   return /^[a-z]/.test(slug)
 }
 
-/* Returns the canonical venue slug for a location hash like "#stage-a", or
-   null when the hash is empty, a coordinate hash, or carries parameters —
-   those belong to the coordinate URL hash handling */
+/* "#stage-a" -> "stage-a"; null for coordinate hashes and parameters */
 function parseVenueHash(hash: string): string | null {
   let raw = hash.replace(/^#/, '')
   if (!raw) return null
@@ -48,25 +30,19 @@ function parseVenueHash(hash: string): string | null {
   } catch {
     return null
   }
-  // Delimiters are checked after decoding so percent-encoded forms can't
-  // smuggle a coordinate or parameter hash past the guard
+  // Checked after decoding so %2F etc. can't smuggle delimiters past the guard
   if (raw.includes('/') || raw.includes('=')) return null
   const slug = slugify(raw)
   return isVenueSlug(slug) ? slug : null
 }
 
-/* Attached as MapLibre eventData to camera moves initiated by venue
-   resolution, so the movestart listener can tell them from user moves */
+/* eventData tag exempting venue flyTo/fitBounds from slug clearing */
 export const VENUE_MOVE = { venueMove: true }
 
-/* URLHash that can hold a venue slug (e.g. #stage-a) in place of the usual
-   coordinate hash. Programmatic venue flights keep the slug in the URL; any
-   other camera movement (drag, wheel, keyboard, zoom buttons, geolocate)
-   reverts to coordinates. Inert unless a slug is set or arrives in the hash.
-
-   Note: this subclass overrides/uses the library's underscore-prefixed
-   internals (_onHashChange, _updateHash, _map). They are typed but
-   undocumented — re-check them when upgrading @russss/maplibregl-layer-switcher. */
+/* URLHash that can hold a venue slug (#stage-a) instead of the coordinate
+   hash. User camera moves revert to coordinates; venue flights don't.
+   Uses the library's underscore-prefixed internals (_onHashChange,
+   _updateHash, _map) — re-check on layer-switcher upgrades. */
 export default class VenueURLHash extends URLHash {
   venueSlug: string | null = null
   onVenueSlug?: (slug: string | null) => void
@@ -82,9 +58,8 @@ export default class VenueURLHash extends URLHash {
     if (this._map) this._updateHash()
   }
 
-  /* Parameters (e.g. the marker position) only appear in coordinate hashes,
-     so setting one while a venue slug is active leaves venue mode — otherwise
-     the copied URL would silently lose the parameter */
+  /* Parameters (e.g. the marker's m=) only appear in coordinate hashes, so
+     setting one leaves venue mode or the copied URL would lose it */
   setParameter(key: string, value: string | null) {
     if (this.venueSlug && value !== null) {
       this.setVenueSlug(null)
@@ -100,22 +75,16 @@ export default class VenueURLHash extends URLHash {
       this.venueSlug = null
       this.onVenueSlug?.(null)
     }
-    // A user-driven camera move means the view is no longer "the venue", so
-    // the hash reverts to coordinates. User moves carry originalEvent (drag,
-    // zoom buttons, keyboard, double-click, pinch) or geolocateSource
-    // (geolocate flights). Venue flights are tagged VENUE_MOVE, and resize
-    // fires movestart with neither — it must not clear the slug.
+    // User moves carry originalEvent (drag, zoom buttons, keyboard, pinch) or
+    // geolocateSource; resize fires movestart with neither and must not clear
     map.on(
       'movestart',
       (e: maplibregl.MapLibreEvent & { venueMove?: boolean; geolocateSource?: boolean }) => {
-        if (e.venueMove) return
-        if (e.originalEvent || e.geolocateSource) clearSlug()
-        // The moveend that follows rewrites the hash to coordinates
+        if (!e.venueMove && (e.originalEvent || e.geolocateSource)) clearSlug()
       }
     )
-    // Wheel zoom's movestart carries no originalEvent, so it needs its own
-    // listener. Rewrite the hash immediately: a wheel at the zoom limit
-    // produces no moveend to do it.
+    // Wheel zoom's movestart carries no originalEvent; rewrite immediately
+    // because a wheel at the zoom limit produces no moveend
     map.on('wheel', () => {
       if (!this.venueSlug) return
       clearSlug()
@@ -126,19 +95,17 @@ export default class VenueURLHash extends URLHash {
   _onHashChange(new_hash: string) {
     const slug = parseVenueHash(new_hash)
     if (slug) {
-      // Never forward slug hashes to the coordinate parser: it would wipe
-      // registered parameters (e.g. the marker's m=) from memory
       if (slug !== this.venueSlug) {
         this.venueSlug = slug
         this.onVenueSlug?.(slug)
       }
-      // Canonicalize the URL bar (e.g. #Stage%20A -> #stage-a)
+      // Canonicalize the URL bar (#Stage%20A -> #stage-a); never forward slug
+      // hashes to super, which would wipe registered parameters from memory
       if (this._map && new_hash !== '#' + slug) this._updateHash()
       return
     }
     if (this.venueSlug) {
-      // Leaving venue mode via the URL bar or history navigation; clear the
-      // slug before delegating or the next moveend would clobber the new hash
+      // Clear before delegating or the next moveend would clobber the new hash
       this.venueSlug = null
       this.onVenueSlug?.(null)
     }

--- a/web/src/venueurlhash.ts
+++ b/web/src/venueurlhash.ts
@@ -1,37 +1,72 @@
 import { URLHash } from '@russss/maplibregl-layer-switcher'
-import maplibregl from 'maplibre-gl'
+import type maplibregl from 'maplibre-gl'
+
+/* Strip diacritics and lowercase. Shared by slugify and the search index's
+   normalize so URL matching and search matching can never drift apart. */
+export function fold(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+}
+
+// Letters that NFD leaves undecomposed, mapped so venue names like "Røde Bar"
+// still get a predictable slug (rode-bar, not r-de-bar)
+const TRANSLITERATIONS: Record<string, string> = {
+  ø: 'o',
+  æ: 'ae',
+  ß: 'ss',
+  ł: 'l',
+  đ: 'd',
+  ð: 'd',
+  þ: 'th',
+}
 
 /* Canonical URL slug for a venue name: "Stage A" -> "stage-a",
    "Parking: Main" -> "parking-main", "Crêche" -> "creche" */
 export function slugify(name: string): string {
-  return name
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .toLowerCase()
+  return fold(name)
+    .replace(/[øæßłđðþ]/g, (c) => TRANSLITERATIONS[c])
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
+}
+
+/* Venue slugs must start with a letter so numeric fragments are never
+   mistaken for venues */
+export function isVenueSlug(slug: string): boolean {
+  return /^[a-z]/.test(slug)
 }
 
 /* Returns the canonical venue slug for a location hash like "#stage-a", or
    null when the hash is empty, a coordinate hash, or carries parameters —
    those belong to the coordinate URL hash handling */
-export function parseVenueHash(hash: string): string | null {
+function parseVenueHash(hash: string): string | null {
   let raw = hash.replace(/^#/, '')
-  if (!raw || raw.includes('/') || raw.includes('=')) return null
+  if (!raw) return null
   try {
     raw = decodeURIComponent(raw)
   } catch {
     return null
   }
+  // Delimiters are checked after decoding so percent-encoded forms can't
+  // smuggle a coordinate or parameter hash past the guard
+  if (raw.includes('/') || raw.includes('=')) return null
   const slug = slugify(raw)
-  // Require a leading letter so numeric fragments are never venue slugs
-  return /^[a-z]/.test(slug) ? slug : null
+  return isVenueSlug(slug) ? slug : null
 }
 
+/* Attached as MapLibre eventData to camera moves initiated by venue
+   resolution, so the movestart listener can tell them from user moves */
+export const VENUE_MOVE = { venueMove: true }
+
 /* URLHash that can hold a venue slug (e.g. #stage-a) in place of the usual
-   coordinate hash. While a slug is active, map movement keeps the slug in the
-   URL; a user-initiated gesture (drag/wheel/pinch) reverts to coordinates.
-   Inert unless setVenueSlug is called or the page hash is a venue slug. */
+   coordinate hash. Programmatic venue flights keep the slug in the URL; any
+   other camera movement (drag, wheel, keyboard, zoom buttons, geolocate)
+   reverts to coordinates. Inert unless a slug is set or arrives in the hash.
+
+   Note: this subclass overrides/uses the library's underscore-prefixed
+   internals (_onHashChange, _updateHash, _map). They are typed but
+   undocumented — re-check them when upgrading @russss/maplibregl-layer-switcher. */
 export default class VenueURLHash extends URLHash {
   venueSlug: string | null = null
   onVenueSlug?: (slug: string | null) => void
@@ -47,22 +82,45 @@ export default class VenueURLHash extends URLHash {
     if (this._map) this._updateHash()
   }
 
+  /* Parameters (e.g. the marker position) only appear in coordinate hashes,
+     so setting one while a venue slug is active leaves venue mode — otherwise
+     the copied URL would silently lose the parameter */
+  setParameter(key: string, value: string | null) {
+    if (this.venueSlug && value !== null) {
+      this.setVenueSlug(null)
+      this.onVenueSlug?.(null)
+    }
+    super.setParameter(key, value)
+  }
+
   enable(map: maplibregl.Map) {
     super.enable(map)
-    // A user camera gesture means the view is no longer "the venue", so the
-    // hash reverts to coordinates. These events fire only on user input (a
-    // wheel zoom's movestart carries no originalEvent, so movestart alone
-    // can't tell user moves from the venue flyTo, which fires none of these)
     const clearSlug = () => {
-      if (this.venueSlug) {
-        this.venueSlug = null
-        this.onVenueSlug?.(null)
-      }
+      if (!this.venueSlug) return
+      this.venueSlug = null
+      this.onVenueSlug?.(null)
     }
-    map.on('dragstart', clearSlug)
-    map.on('wheel', clearSlug)
-    map.on('dblclick', clearSlug)
-    map.on('touchmove', clearSlug)
+    // A user-driven camera move means the view is no longer "the venue", so
+    // the hash reverts to coordinates. User moves carry originalEvent (drag,
+    // zoom buttons, keyboard, double-click, pinch) or geolocateSource
+    // (geolocate flights). Venue flights are tagged VENUE_MOVE, and resize
+    // fires movestart with neither — it must not clear the slug.
+    map.on(
+      'movestart',
+      (e: maplibregl.MapLibreEvent & { venueMove?: boolean; geolocateSource?: boolean }) => {
+        if (e.venueMove) return
+        if (e.originalEvent || e.geolocateSource) clearSlug()
+        // The moveend that follows rewrites the hash to coordinates
+      }
+    )
+    // Wheel zoom's movestart carries no originalEvent, so it needs its own
+    // listener. Rewrite the hash immediately: a wheel at the zoom limit
+    // produces no moveend to do it.
+    map.on('wheel', () => {
+      if (!this.venueSlug) return
+      clearSlug()
+      if (this._map) this._updateHash()
+    })
   }
 
   _onHashChange(new_hash: string) {
@@ -74,6 +132,8 @@ export default class VenueURLHash extends URLHash {
         this.venueSlug = slug
         this.onVenueSlug?.(slug)
       }
+      // Canonicalize the URL bar (e.g. #Stage%20A -> #stage-a)
+      if (this._map && new_hash !== '#' + slug) this._updateHash()
       return
     }
     if (this.venueSlug) {

--- a/web/src/venueurlhash.ts
+++ b/web/src/venueurlhash.ts
@@ -1,0 +1,87 @@
+import { URLHash } from '@russss/maplibregl-layer-switcher'
+import maplibregl from 'maplibre-gl'
+
+/* Canonical URL slug for a venue name: "Stage A" -> "stage-a",
+   "Parking: Main" -> "parking-main", "Crêche" -> "creche" */
+export function slugify(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/* Returns the canonical venue slug for a location hash like "#stage-a", or
+   null when the hash is empty, a coordinate hash, or carries parameters —
+   those belong to the coordinate URL hash handling */
+export function parseVenueHash(hash: string): string | null {
+  let raw = hash.replace(/^#/, '')
+  if (!raw || raw.includes('/') || raw.includes('=')) return null
+  try {
+    raw = decodeURIComponent(raw)
+  } catch {
+    return null
+  }
+  const slug = slugify(raw)
+  // Require a leading letter so numeric fragments are never venue slugs
+  return /^[a-z]/.test(slug) ? slug : null
+}
+
+/* URLHash that can hold a venue slug (e.g. #stage-a) in place of the usual
+   coordinate hash. While a slug is active, map movement keeps the slug in the
+   URL; a user-initiated gesture (drag/wheel/pinch) reverts to coordinates.
+   Inert unless setVenueSlug is called or the page hash is a venue slug. */
+export default class VenueURLHash extends URLHash {
+  venueSlug: string | null = null
+  onVenueSlug?: (slug: string | null) => void
+
+  getHashString(): string {
+    if (this.venueSlug) return '#' + this.venueSlug
+    return super.getHashString()
+  }
+
+  setVenueSlug(slug: string | null) {
+    if (slug === this.venueSlug) return
+    this.venueSlug = slug
+    if (this._map) this._updateHash()
+  }
+
+  enable(map: maplibregl.Map) {
+    super.enable(map)
+    // A user camera gesture means the view is no longer "the venue", so the
+    // hash reverts to coordinates. These events fire only on user input (a
+    // wheel zoom's movestart carries no originalEvent, so movestart alone
+    // can't tell user moves from the venue flyTo, which fires none of these)
+    const clearSlug = () => {
+      if (this.venueSlug) {
+        this.venueSlug = null
+        this.onVenueSlug?.(null)
+      }
+    }
+    map.on('dragstart', clearSlug)
+    map.on('wheel', clearSlug)
+    map.on('dblclick', clearSlug)
+    map.on('touchmove', clearSlug)
+  }
+
+  _onHashChange(new_hash: string) {
+    const slug = parseVenueHash(new_hash)
+    if (slug) {
+      // Never forward slug hashes to the coordinate parser: it would wipe
+      // registered parameters (e.g. the marker's m=) from memory
+      if (slug !== this.venueSlug) {
+        this.venueSlug = slug
+        this.onVenueSlug?.(slug)
+      }
+      return
+    }
+    if (this.venueSlug) {
+      // Leaving venue mode via the URL bar or history navigation; clear the
+      // slug before delegating or the next moveend would clobber the new hash
+      this.venueSlug = null
+      this.onVenueSlug?.(null)
+    }
+    super._onHashChange(new_hash)
+  }
+}


### PR DESCRIPTION
Fixes #56

You can now link to venues by name as well as: https://map.emfcamp.org/#stage-a, https://map.emfcamp.org#the-robot-arms, https://map.emfcamp.org/#parking (highlights all parking), builds on and shared logic from https://github.com/emfcamp/map/pull/68

This means links keep working between events. Panning or zooming returns to the coordinate URLs that are already supported.