### PR TITLE
Add live trackers to search

### DIFF
--- a/web/src/search/search.css
+++ b/web/src/search/search.css
@@ -173,3 +173,15 @@
 .search-badge-village {
   background-color: #7a4bbd;
 }
+
+.search-badge-vehicle {
+  background-color: #0f766e;
+}
+
+.search-badge-bus {
+  background-color: #b21e4b;
+}
+
+.search-badge-person {
+  background-color: #4338ca;
+}

--- a/web/src/search/searchcontrol.ts
+++ b/web/src/search/searchcontrol.ts
@@ -48,8 +48,6 @@ class SearchControl implements maplibregl.IControl {
   _activeIndex: number = -1
   _highlighted: SearchEntry[] = []
   _unsubscribeTracking?: () => void
-  _followFrame?: number
-  _lastHighlightKey?: string
 
   constructor() {
     this._toggleButton = el('button.search-toggle', {
@@ -314,8 +312,7 @@ class SearchControl implements maplibregl.IControl {
     this._input.removeAttribute('aria-activedescendant')
   }
 
-  /* Where an entry is right now: tracked entities may have moved since the
-     query, so read the live position and fall back to the query-time coords. */
+  // Live position of a tracked entry, falling back to its query-time coords
   _liveCoords(entry: SearchEntry): [number, number] {
     return (entry.tracked && trackingPosition(entry.tracked.type, entry.tracked.id)) || entry.coords
   }
@@ -353,35 +350,20 @@ class SearchControl implements maplibregl.IControl {
     this._renderHighlights()
   }
 
-  /* Follow live entities only while one is highlighted: subscribe so the halo
-     tracks it, and tear the subscription down once nothing tracked remains. */
+  // Follow live entities while one is highlighted, so the halo tracks them;
+  // drop the subscription once nothing tracked is left
   _syncFollow() {
     const following = this._highlighted.some((entry) => entry.tracked)
     if (following && !this._unsubscribeTracking) {
-      // Tracking fires per layer per frame; coalesce into one render per frame
-      this._unsubscribeTracking = subscribeTrackingUpdates(() => this._scheduleHighlightRender())
+      this._unsubscribeTracking = subscribeTrackingUpdates(() => this._renderHighlights())
     } else if (!following && this._unsubscribeTracking) {
       this._unsubscribeTracking()
       this._unsubscribeTracking = undefined
-      if (this._followFrame != null) {
-        cancelAnimationFrame(this._followFrame)
-        this._followFrame = undefined
-      }
     }
   }
 
-  _scheduleHighlightRender() {
-    if (this._followFrame != null) return
-    this._followFrame = requestAnimationFrame(() => {
-      this._followFrame = undefined
-      this._renderHighlights()
-    })
-  }
-
-  /* Rebuild the highlight source from the current list, reading live positions
-     for tracked entries. Entities that have expired or whose layer was switched
-     off resolve to no coords and are pruned, which also stops the follow once
-     nothing live is left. Skips the GPU upload when nothing actually moved. */
+  // Rebuild the halo from live positions; a tracked entity that expired or whose
+  // layer was turned off resolves to no coords, drops out and stops the follow
   _renderHighlights() {
     const source = this._map?.getSource('search_results') as GeoJSONSource | undefined
     if (!source) return
@@ -401,9 +383,6 @@ class SearchControl implements maplibregl.IControl {
       this._highlighted = live
       this._syncFollow()
     }
-    const key = JSON.stringify(features)
-    if (key === this._lastHighlightKey) return
-    this._lastHighlightKey = key
     source.setData({ type: 'FeatureCollection', features })
     this._toggleButton.classList.toggle('active', features.length > 0)
   }

--- a/web/src/search/searchcontrol.ts
+++ b/web/src/search/searchcontrol.ts
@@ -1,6 +1,7 @@
 import { el, mount } from 'redom'
 import maplibregl, { GeoJSONSource, LngLatBounds } from 'maplibre-gl'
 import type { SearchCategory, SearchEntry, SearchIndex } from './searchindex.ts'
+import { trackingSearchEntries, trackingPosition, subscribeTrackingUpdates } from '../tracking.ts'
 
 const categoryZoom: Record<SearchCategory, number> = {
   structure: 18,
@@ -9,6 +10,9 @@ const categoryZoom: Record<SearchCategory, number> = {
   area: 17,
   camping: 16.5,
   parking: 16.5,
+  vehicle: 18,
+  bus: 17.5,
+  person: 18,
 }
 
 /* Zoom cap when fitting all results at once; matches the widest per-category
@@ -22,9 +26,10 @@ const categoryLabel: Record<SearchCategory, string> = {
   parking: 'parking',
   gate: 'gate',
   village: 'village',
+  vehicle: 'vehicle',
+  bus: 'bus',
+  person: 'person',
 }
-
-const emptyCollection: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] }
 
 class SearchControl implements maplibregl.IControl {
   _map?: maplibregl.Map
@@ -40,6 +45,8 @@ class SearchControl implements maplibregl.IControl {
   _searchFn?: typeof import('./searchindex.ts').search
   _results: SearchEntry[] = []
   _activeIndex: number = -1
+  _highlighted: SearchEntry[] = []
+  _unsubscribeTracking?: () => void
 
   constructor() {
     this._toggleButton = el('button.search-toggle', {
@@ -241,7 +248,10 @@ class SearchControl implements maplibregl.IControl {
       return
     }
 
-    this._results = this._searchFn(this._index.entries, query)
+    // Live tracked entities are merged in per query so their positions and
+    // enabled state are current; only enabled layers contribute entries
+    const trackingEntries = this._map ? trackingSearchEntries(this._map) : []
+    this._results = this._searchFn([...this._index.entries, ...trackingEntries], query)
     this._input.setAttribute('aria-expanded', 'true')
 
     if (this._index.offline) {
@@ -303,7 +313,9 @@ class SearchControl implements maplibregl.IControl {
 
   _select(entry: SearchEntry) {
     this._setHighlights([entry])
-    this._map?.flyTo({ center: entry.coords, zoom: categoryZoom[entry.category] })
+    // Tracked entities may have moved since the query; fly to where they are now
+    const center = (entry.tracked && trackingPosition(entry.tracked.type, entry.tracked.id)) || entry.coords
+    this._map?.flyTo({ center, zoom: categoryZoom[entry.category] })
     this._afterSelection()
   }
 
@@ -328,22 +340,36 @@ class SearchControl implements maplibregl.IControl {
   }
 
   _setHighlights(entries: SearchEntry[]) {
+    this._highlighted = entries
+    // Subscribe to tracking updates only while a live entity is highlighted,
+    // so its halo follows it; unsubscribe once nothing tracked remains
+    const following = entries.some((entry) => entry.tracked)
+    if (following && !this._unsubscribeTracking) {
+      this._unsubscribeTracking = subscribeTrackingUpdates(() => this._renderHighlights())
+    } else if (!following && this._unsubscribeTracking) {
+      this._unsubscribeTracking()
+      this._unsubscribeTracking = undefined
+    }
+    this._renderHighlights()
+  }
+
+  /* Rebuild the highlight source from the current highlight list, reading live
+     positions for tracked entries and dropping any that have gone away. */
+  _renderHighlights() {
     const source = this._map?.getSource('search_results') as GeoJSONSource | undefined
     if (!source) return
-    if (entries.length === 0) {
-      source.setData(emptyCollection)
-      this._toggleButton.classList.remove('active')
-      return
-    }
-    source.setData({
-      type: 'FeatureCollection',
-      features: entries.map((entry) => ({
+    const features: GeoJSON.Feature[] = []
+    for (const entry of this._highlighted) {
+      const coords = entry.tracked ? trackingPosition(entry.tracked.type, entry.tracked.id) : entry.coords
+      if (!coords) continue
+      features.push({
         type: 'Feature',
-        geometry: { type: 'Point', coordinates: entry.coords },
+        geometry: { type: 'Point', coordinates: coords },
         properties: { name: entry.displayName, category: entry.category },
-      })),
-    })
-    this._toggleButton.classList.add('active')
+      })
+    }
+    source.setData({ type: 'FeatureCollection', features })
+    this._toggleButton.classList.toggle('active', features.length > 0)
   }
 }
 

--- a/web/src/search/searchcontrol.ts
+++ b/web/src/search/searchcontrol.ts
@@ -1,6 +1,7 @@
 import { el, mount } from 'redom'
 import maplibregl, { GeoJSONSource, LngLatBounds } from 'maplibre-gl'
-import type { SearchCategory, SearchEntry, SearchIndex } from './searchindex.ts'
+import type { SearchIndex } from './searchindex.ts'
+import type { SearchCategory, SearchEntry } from './searchentry.ts'
 import { trackingSearchEntries, trackingPosition, subscribeTrackingUpdates } from '../tracking.ts'
 
 const categoryZoom: Record<SearchCategory, number> = {
@@ -47,6 +48,8 @@ class SearchControl implements maplibregl.IControl {
   _activeIndex: number = -1
   _highlighted: SearchEntry[] = []
   _unsubscribeTracking?: () => void
+  _followFrame?: number
+  _lastHighlightKey?: string
 
   constructor() {
     this._toggleButton = el('button.search-toggle', {
@@ -311,20 +314,25 @@ class SearchControl implements maplibregl.IControl {
     this._input.removeAttribute('aria-activedescendant')
   }
 
+  /* Where an entry is right now: tracked entities may have moved since the
+     query, so read the live position and fall back to the query-time coords. */
+  _liveCoords(entry: SearchEntry): [number, number] {
+    return (entry.tracked && trackingPosition(entry.tracked.type, entry.tracked.id)) || entry.coords
+  }
+
   _select(entry: SearchEntry) {
     this._setHighlights([entry])
-    // Tracked entities may have moved since the query; fly to where they are now
-    const center = (entry.tracked && trackingPosition(entry.tracked.type, entry.tracked.id)) || entry.coords
-    this._map?.flyTo({ center, zoom: categoryZoom[entry.category] })
+    this._map?.flyTo({ center: this._liveCoords(entry), zoom: categoryZoom[entry.category] })
     this._afterSelection()
   }
 
   _selectAll() {
     const results = this._results
     this._setHighlights(results)
+    const first = this._liveCoords(results[0])
     const bounds = results.reduce(
-      (b, entry) => b.extend(entry.coords),
-      new LngLatBounds(results[0].coords, results[0].coords)
+      (b, entry) => b.extend(this._liveCoords(entry)),
+      new LngLatBounds(first, first)
     )
     this._map?.fitBounds(bounds, {
       padding: { top: 90, bottom: 50, left: 50, right: 50 },
@@ -341,33 +349,61 @@ class SearchControl implements maplibregl.IControl {
 
   _setHighlights(entries: SearchEntry[]) {
     this._highlighted = entries
-    // Subscribe to tracking updates only while a live entity is highlighted,
-    // so its halo follows it; unsubscribe once nothing tracked remains
-    const following = entries.some((entry) => entry.tracked)
-    if (following && !this._unsubscribeTracking) {
-      this._unsubscribeTracking = subscribeTrackingUpdates(() => this._renderHighlights())
-    } else if (!following && this._unsubscribeTracking) {
-      this._unsubscribeTracking()
-      this._unsubscribeTracking = undefined
-    }
+    this._syncFollow()
     this._renderHighlights()
   }
 
-  /* Rebuild the highlight source from the current highlight list, reading live
-     positions for tracked entries and dropping any that have gone away. */
+  /* Follow live entities only while one is highlighted: subscribe so the halo
+     tracks it, and tear the subscription down once nothing tracked remains. */
+  _syncFollow() {
+    const following = this._highlighted.some((entry) => entry.tracked)
+    if (following && !this._unsubscribeTracking) {
+      // Tracking fires per layer per frame; coalesce into one render per frame
+      this._unsubscribeTracking = subscribeTrackingUpdates(() => this._scheduleHighlightRender())
+    } else if (!following && this._unsubscribeTracking) {
+      this._unsubscribeTracking()
+      this._unsubscribeTracking = undefined
+      if (this._followFrame != null) {
+        cancelAnimationFrame(this._followFrame)
+        this._followFrame = undefined
+      }
+    }
+  }
+
+  _scheduleHighlightRender() {
+    if (this._followFrame != null) return
+    this._followFrame = requestAnimationFrame(() => {
+      this._followFrame = undefined
+      this._renderHighlights()
+    })
+  }
+
+  /* Rebuild the highlight source from the current list, reading live positions
+     for tracked entries. Entities that have expired or whose layer was switched
+     off resolve to no coords and are pruned, which also stops the follow once
+     nothing live is left. Skips the GPU upload when nothing actually moved. */
   _renderHighlights() {
     const source = this._map?.getSource('search_results') as GeoJSONSource | undefined
     if (!source) return
     const features: GeoJSON.Feature[] = []
+    const live: SearchEntry[] = []
     for (const entry of this._highlighted) {
       const coords = entry.tracked ? trackingPosition(entry.tracked.type, entry.tracked.id) : entry.coords
       if (!coords) continue
+      live.push(entry)
       features.push({
         type: 'Feature',
         geometry: { type: 'Point', coordinates: coords },
         properties: { name: entry.displayName, category: entry.category },
       })
     }
+    if (live.length < this._highlighted.length) {
+      this._highlighted = live
+      this._syncFollow()
+    }
+    const key = JSON.stringify(features)
+    if (key === this._lastHighlightKey) return
+    this._lastHighlightKey = key
     source.setData({ type: 'FeatureCollection', features })
     this._toggleButton.classList.toggle('active', features.length > 0)
   }

--- a/web/src/search/searchentry.ts
+++ b/web/src/search/searchentry.ts
@@ -31,9 +31,10 @@ export function normalize(s: string): string {
     .trim()
 }
 
-/* Village data is attendee-editable, so coordinates can't be trusted to be
-   well-formed; a bad entry must not break selection or bounds fitting */
-function validCoords(coords: unknown): coords is [number, number] {
+/* Village data is attendee-editable and live tracker positions arrive from an
+   external stream, so coordinates can't be trusted to be well-formed; a bad
+   entry must not break selection, bounds fitting or a flyTo. */
+export function validCoords(coords: unknown): coords is [number, number] {
   return (
     Array.isArray(coords) &&
     coords.length >= 2 &&

--- a/web/src/search/searchentry.ts
+++ b/web/src/search/searchentry.ts
@@ -1,8 +1,6 @@
-/* Dependency-free search entry types and constructors, shared by the lazily
-   loaded search index (searchindex.ts) and the eager tracking module. Keeping
-   these here means tracking.ts can build entries without statically importing
-   searchindex.ts, which would pull its heavy VectorTile/Pbf deps into the
-   initial bundle. */
+// Shared search entry types and builders. Kept dependency-free so tracking.ts
+// can build entries without dragging searchindex.ts's VectorTile/Pbf deps into
+// the initial bundle.
 
 export type SearchCategory =
   'structure' | 'area' | 'camping' | 'parking' | 'gate' | 'village' | 'vehicle' | 'bus' | 'person'

--- a/web/src/search/searchentry.ts
+++ b/web/src/search/searchentry.ts
@@ -1,0 +1,63 @@
+/* Dependency-free search entry types and constructors, shared by the lazily
+   loaded search index (searchindex.ts) and the eager tracking module. Keeping
+   these here means tracking.ts can build entries without statically importing
+   searchindex.ts, which would pull its heavy VectorTile/Pbf deps into the
+   initial bundle. */
+
+export type SearchCategory =
+  'structure' | 'area' | 'camping' | 'parking' | 'gate' | 'village' | 'vehicle' | 'bus' | 'person'
+
+/* Identifies a live tracked feature so its highlight can follow the moving
+   entity. Absent on static site-plan and village entries. */
+export interface TrackedRef {
+  type: string
+  id: string
+}
+
+export interface SearchEntry {
+  displayName: string
+  normalized: string
+  category: SearchCategory
+  coords: [number, number]
+  importance: number
+  tracked?: TrackedRef
+}
+
+export function normalize(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+}
+
+/* Village data is attendee-editable, so coordinates can't be trusted to be
+   well-formed; a bad entry must not break selection or bounds fitting */
+function validCoords(coords: unknown): coords is [number, number] {
+  return (
+    Array.isArray(coords) &&
+    coords.length >= 2 &&
+    Number.isFinite(coords[0]) &&
+    Number.isFinite(coords[1]) &&
+    Math.abs(coords[0]) <= 180 &&
+    Math.abs(coords[1]) <= 90
+  )
+}
+
+export function makeEntry(
+  category: SearchCategory,
+  displayName: string,
+  geometry: GeoJSON.Geometry | null | undefined,
+  importance: number,
+  tracked?: TrackedRef
+): SearchEntry | undefined {
+  if (geometry?.type !== 'Point' || !validCoords(geometry.coordinates)) return undefined
+  return {
+    displayName,
+    normalized: normalize(displayName),
+    category,
+    coords: geometry.coordinates as [number, number],
+    importance,
+    ...(tracked ? { tracked } : {}),
+  }
+}

--- a/web/src/search/searchindex.ts
+++ b/web/src/search/searchindex.ts
@@ -5,8 +5,6 @@ import { center } from '../style/map_style.ts'
 import { makeEntry, normalize } from './searchentry.ts'
 import type { SearchCategory, SearchEntry } from './searchentry.ts'
 
-export type { SearchCategory, SearchEntry, TrackedRef } from './searchentry.ts'
-
 export interface SearchIndex {
   entries: SearchEntry[]
   /* True when the site plan tile couldn't be fetched and the index only

--- a/web/src/search/searchindex.ts
+++ b/web/src/search/searchindex.ts
@@ -2,16 +2,10 @@ import { VectorTile } from '@mapbox/vector-tile'
 import Pbf from 'pbf'
 import maplibregl, { GeoJSONSource } from 'maplibre-gl'
 import { center } from '../style/map_style.ts'
+import { makeEntry, normalize } from './searchentry.ts'
+import type { SearchCategory, SearchEntry } from './searchentry.ts'
 
-export type SearchCategory = 'structure' | 'area' | 'camping' | 'parking' | 'gate' | 'village'
-
-export interface SearchEntry {
-  displayName: string
-  normalized: string
-  category: SearchCategory
-  coords: [number, number]
-  importance: number
-}
+export type { SearchCategory, SearchEntry, TrackedRef } from './searchentry.ts'
 
 export interface SearchIndex {
   entries: SearchEntry[]
@@ -28,48 +22,11 @@ const INDEX_TILE_ZOOM = 11
 const TILE_FETCH_TIMEOUT_MS = 5000
 const DEFAULT_IMPORTANCE = 3
 
-function normalize(s: string): string {
-  return s
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-}
-
 function tileForPoint(lng: number, lat: number, z: number): { x: number; y: number } {
   const latR = (lat * Math.PI) / 180
   const x = Math.floor(((lng + 180) / 360) * 2 ** z)
   const y = Math.floor(((1 - Math.log(Math.tan(latR) + 1 / Math.cos(latR)) / Math.PI) / 2) * 2 ** z)
   return { x, y }
-}
-
-/* Village data is attendee-editable, so coordinates can't be trusted to be
-   well-formed; a bad entry must not break selection or bounds fitting */
-function validCoords(coords: unknown): coords is [number, number] {
-  return (
-    Array.isArray(coords) &&
-    coords.length >= 2 &&
-    Number.isFinite(coords[0]) &&
-    Number.isFinite(coords[1]) &&
-    Math.abs(coords[0]) <= 180 &&
-    Math.abs(coords[1]) <= 90
-  )
-}
-
-function makeEntry(
-  category: SearchCategory,
-  displayName: string,
-  geometry: GeoJSON.Geometry | null | undefined,
-  importance: number
-): SearchEntry | undefined {
-  if (geometry?.type !== 'Point' || !validCoords(geometry.coordinates)) return undefined
-  return {
-    displayName,
-    normalized: normalize(displayName),
-    category,
-    coords: geometry.coordinates as [number, number],
-    importance,
-  }
 }
 
 interface LayerExtractor {

--- a/web/src/tracking.ts
+++ b/web/src/tracking.ts
@@ -32,8 +32,7 @@ interface TrackingLayer {
   frame?: number
 }
 
-/* Tracked entities sort below venues on an equal text score; the query match
-   itself dominates, so this only breaks ties. */
+// Only breaks ties; a tracker sorts just below a venue on an equal text score
 const TRACKED_IMPORTANCE = 1
 
 const relativeTime = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
@@ -61,9 +60,8 @@ function refreshTimes(content: HTMLElement) {
   })
 }
 
-/* Display names shared by the popups and the search index, so a tracked
-   entity reads the same in the results list as in its popup title. Each
-   returns undefined when it has no usable name, so it can be left out of search. */
+// Display names shared by the popups and search, so a tracker reads the same in
+// both. Return undefined when there's no usable name, so search can skip it.
 function vehicleName(props: Record<string, any>): string | undefined {
   if (props.vehicleType) {
     return `${props.vehicleType}${props.registration ? ` (${props.registration})` : ''}`
@@ -186,9 +184,8 @@ function moving(layer: TrackingLayer, id: string, now: number): Position | undef
   return [move.from[0] + (move.to[0] - move.from[0]) * p, move.from[1] + (move.to[1] - move.from[1]) * p]
 }
 
-/* Fired after every tracking render so a search highlight can follow a moving
-   entity. render() only runs while things move (per-frame), on stream updates,
-   and on the 60s sweep, so an idle subscriber costs nothing. */
+// Fired after every render so a search highlight can follow a moving entity.
+// render() only runs when things change, so an idle subscriber costs nothing.
 const updateListeners = new Set<() => void>()
 
 export function subscribeTrackingUpdates(listener: () => void): () => void {
@@ -267,9 +264,8 @@ function visible(map: maplibregl.Map, layer: TrackingLayer): boolean {
   return map.getLayoutProperty(layer.layer, 'visibility') !== 'none'
 }
 
-/* Live search entries for every enabled tracking layer, rebuilt on each query
-   so positions and the enabled set are always current. Stale features and
-   ones without a usable name are skipped. */
+// Search entries for enabled tracking layers, rebuilt each query so positions
+// and the enabled set stay current. Skips stale and unnamed features.
 export function trackingSearchEntries(map: maplibregl.Map): SearchEntry[] {
   const entries: SearchEntry[] = []
   for (const layer of trackingLayers) {

--- a/web/src/tracking.ts
+++ b/web/src/tracking.ts
@@ -1,7 +1,7 @@
 import maplibregl from 'maplibre-gl'
 import type { Feature, FeatureCollection, Position } from 'geojson'
 import { el, mount } from 'redom'
-import { makeEntry } from './search/searchentry.ts'
+import { makeEntry, validCoords } from './search/searchentry.ts'
 import type { SearchCategory, SearchEntry } from './search/searchentry.ts'
 import './tracking.css'
 
@@ -297,7 +297,7 @@ export function trackingPosition(type: string, id: string): [number, number] | u
   if (!feature || !fresh(feature) || feature.geometry.type !== 'Point') return undefined
   const now = performance.now()
   const coords = moving(layer, id, now) ?? feature.geometry.coordinates
-  return [coords[0], coords[1]]
+  return validCoords(coords) ? [coords[0], coords[1]] : undefined
 }
 
 function disconnect() {

--- a/web/src/tracking.ts
+++ b/web/src/tracking.ts
@@ -1,6 +1,8 @@
 import maplibregl from 'maplibre-gl'
 import type { Feature, FeatureCollection, Position } from 'geojson'
 import { el, mount } from 'redom'
+import { makeEntry } from './search/searchentry.ts'
+import type { SearchCategory, SearchEntry } from './search/searchentry.ts'
 import './tracking.css'
 
 const TRACKING_HOST = import.meta.env.DEV ? 'http://localhost:3000' : 'https://emf.eventwan.net'
@@ -21,12 +23,18 @@ interface TrackingLayer {
   layer: string
   source: string
   snapshot: string
+  category: SearchCategory
   id: (props: Record<string, any>) => string | undefined
+  name: (props: Record<string, any>) => string | undefined
   popup: (props: Record<string, any>) => HTMLElement
   features: Map<string, Feature>
   moves: Map<string, Move>
   frame?: number
 }
+
+/* Tracked entities sort below venues on an equal text score; the query match
+   itself dominates, so this only breaks ties. */
+const TRACKED_IMPORTANCE = 1
 
 const relativeTime = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
 
@@ -53,12 +61,27 @@ function refreshTimes(content: HTMLElement) {
   })
 }
 
-function vehiclePopup(props: Record<string, any>) {
-  const vehicleName = props.vehicleType
-    ? `${props.vehicleType}${props.registration ? ` (${props.registration})` : ''}`
-    : `Tracker ${props.deviceName}`
+/* Display names shared by the popups and the search index, so a tracked
+   entity reads the same in the results list as in its popup title. Each
+   returns undefined when it has no usable name, so it can be left out of search. */
+function vehicleName(props: Record<string, any>): string | undefined {
+  if (props.vehicleType) {
+    return `${props.vehicleType}${props.registration ? ` (${props.registration})` : ''}`
+  }
+  return props.deviceName != null ? `Tracker ${props.deviceName}` : undefined
+}
 
-  const content = el('.tracking-popup', el('h3', vehicleName))
+function busName(props: Record<string, any>): string | undefined {
+  return props.name != null ? String(props.name) : undefined
+}
+
+function personName(props: Record<string, any>): string | undefined {
+  const name = props.name ?? props.deviceName
+  return name != null ? String(name) : undefined
+}
+
+function vehiclePopup(props: Record<string, any>) {
+  const content = el('.tracking-popup', el('h3', vehicleName(props) ?? ''))
   if (props.vehicleType != null) {
     mount(content, el('p', `Tracker ${props.deviceName}`))
   }
@@ -74,7 +97,7 @@ function vehiclePopup(props: Record<string, any>) {
 }
 
 function busPopup(props: Record<string, any>) {
-  const content = el('.tracking-popup', el('h3', props.name))
+  const content = el('.tracking-popup', el('h3', busName(props) ?? ''))
   if (props.address != null) {
     mount(content, el('p', props.address))
   }
@@ -91,7 +114,7 @@ function busPopup(props: Record<string, any>) {
 }
 
 function peoplePopup(props: Record<string, any>) {
-  const content = el('.tracking-popup', el('h3', props.name ?? props.deviceName))
+  const content = el('.tracking-popup', el('h3', personName(props) ?? ''))
   if (props.battery != null) {
     mount(content, el('p', `Battery ${props.battery}%`))
   }
@@ -109,7 +132,9 @@ const trackingLayers: TrackingLayer[] = [
     layer: 'vehicles_symbol',
     source: 'vehicles',
     snapshot: 'vehicles.geojson',
+    category: 'vehicle',
     id: (props) => props.devEui,
+    name: vehicleName,
     popup: vehiclePopup,
     features: new Map(),
     moves: new Map(),
@@ -119,7 +144,9 @@ const trackingLayers: TrackingLayer[] = [
     layer: 'bus_symbol',
     source: 'bus',
     snapshot: 'bus.geojson',
+    category: 'bus',
     id: (props) => props.assetId?.toString(),
+    name: busName,
     popup: busPopup,
     features: new Map(),
     moves: new Map(),
@@ -129,7 +156,9 @@ const trackingLayers: TrackingLayer[] = [
     layer: 'people_symbol',
     source: 'people',
     snapshot: 'people.geojson',
+    category: 'person',
     id: (props) => props.devEui,
+    name: personName,
     popup: peoplePopup,
     features: new Map(),
     moves: new Map(),
@@ -157,6 +186,20 @@ function moving(layer: TrackingLayer, id: string, now: number): Position | undef
   return [move.from[0] + (move.to[0] - move.from[0]) * p, move.from[1] + (move.to[1] - move.from[1]) * p]
 }
 
+/* Fired after every tracking render so a search highlight can follow a moving
+   entity. render() only runs while things move (per-frame), on stream updates,
+   and on the 60s sweep, so an idle subscriber costs nothing. */
+const updateListeners = new Set<() => void>()
+
+export function subscribeTrackingUpdates(listener: () => void): () => void {
+  updateListeners.add(listener)
+  return () => updateListeners.delete(listener)
+}
+
+function notifyUpdate() {
+  for (const listener of updateListeners) listener()
+}
+
 function render(map: maplibregl.Map, layer: TrackingLayer) {
   for (const [id, feature] of layer.features) {
     if (!fresh(feature)) {
@@ -177,6 +220,7 @@ function render(map: maplibregl.Map, layer: TrackingLayer) {
     }),
   }
   source.setData(collection)
+  notifyUpdate()
 
   if (layer.frame != null) cancelAnimationFrame(layer.frame)
   layer.frame = layer.moves.size
@@ -221,6 +265,39 @@ let streamTypes = ''
 function visible(map: maplibregl.Map, layer: TrackingLayer): boolean {
   if (!map.getLayer(layer.layer)) return false
   return map.getLayoutProperty(layer.layer, 'visibility') !== 'none'
+}
+
+/* Live search entries for every enabled tracking layer, rebuilt on each query
+   so positions and the enabled set are always current. Stale features and
+   ones without a usable name are skipped. */
+export function trackingSearchEntries(map: maplibregl.Map): SearchEntry[] {
+  const entries: SearchEntry[] = []
+  for (const layer of trackingLayers) {
+    if (!visible(map, layer)) continue
+    for (const [id, feature] of layer.features) {
+      if (!fresh(feature)) continue
+      const displayName = layer.name(feature.properties ?? {})
+      if (!displayName) continue
+      const entry = makeEntry(layer.category, displayName, feature.geometry, TRACKED_IMPORTANCE, {
+        type: layer.type,
+        id,
+      })
+      if (entry) entries.push(entry)
+    }
+  }
+  return entries
+}
+
+/* Current interpolated position of a tracked feature, or undefined once it has
+   gone stale or dropped out, so a following highlight can drop it too. */
+export function trackingPosition(type: string, id: string): [number, number] | undefined {
+  const layer = trackingLayers.find((l) => l.type === type)
+  if (!layer) return undefined
+  const feature = layer.features.get(id)
+  if (!feature || !fresh(feature) || feature.geometry.type !== 'Point') return undefined
+  const now = performance.now()
+  const coords = moving(layer, id, now) ?? feature.geometry.coordinates
+  return [coords[0], coords[1]]
 }
 
 function disconnect() {


### PR DESCRIPTION
Builds on #68 - when a Tracking layer (Vehicles, Busses or People) is switched on, its live trackers become searchable alongside venues. Trackers only show up during search once that layer is on.

Selecting a tracker starts live follow of it.

<img width="2000" height="1932" alt="tracking-search-selected" src="https://github.com/user-attachments/assets/965d2820-1b46-462d-9dc5-192d0f722b0b" />
<img width="2000" height="1932" alt="tracking-search-results" src="https://github.com/user-attachments/assets/d6d96d68-a552-4d0a-8d14-077dd2fbc5a2" />
